### PR TITLE
ci: fix release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Build 👷‍♀
         run: |
           yarn build
+          yarn bundle
 
       - name: Check ✅
         run: |

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "publish:npm": "lerna publish",
     "publish:npm:canary": "lerna publish --canary --no-git-tag-version --no-push --dist-tag prerelease",
     "bundle:clean": "rimraf build",
-    "bundle:copy": "copyfiles -u 1 -a -E \"storybook-static/*\" \"storybook-static/**/*\" build && copyfiles -a -E \"demo/*\" \"demo/**/*\" \"packages/**/dist/*\" \"packagfes/**/dist/**/*\" build",
+    "bundle:copy": "copyfiles -u 1 -a -E \"storybook-static/*\" \"storybook-static/**/*\" build && copyfiles -a -E \"demo/*\" \"demo/**/*\" \"packages/**/dist/*\" \"packages/**/dist/**/*\" build",
     "bundle": "yarn bundle:clean && yarn bundle:copy"
   },
   "dependencies": {


### PR DESCRIPTION
add missing "bundle" task and fix the related script in order to have a `build/` directory to release.