### PR TITLE
ci: stable docs only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4
+        # only update the documentation for stable releases
+        if: github.ref == 'refs/heads/main'
         with:
           folder: build
 


### PR DESCRIPTION
only deploy the documentation and demos to Github pages when releasing
a "final" version (i.e. on main branch)