### PR TITLE
chore(@blindnet/core): remove dependency to lit

### DIFF
--- a/packages/core/import-map.json
+++ b/packages/core/import-map.json
@@ -1,7 +1,0 @@
-{
-	"imports": {
-		"lit/": "https://unpkg.com/lit@~2.2.8/",
-		"lit": "https://unpkg.com/lit@~2.2.8/index.js"
-	},
-	"scopes": {}
-}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,6 +42,5 @@
     "access": "public"
   },
   "dependencies": {
-    "lit": "^2.2.8"
   }
 }

--- a/packages/core/src/hello-world/hello-world.ts
+++ b/packages/core/src/hello-world/hello-world.ts
@@ -1,5 +1,3 @@
-import 'lit';
-
 export function helloCore() {
   // eslint-disable-next-line no-console
   console.log('Hello Core Library');


### PR DESCRIPTION
For now, the core library is just an empty placeholder for future refactorings.
The lit dependency was only added for testing.