### PR TITLE
build: update lerna versionning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,11 +55,11 @@ jobs:
       - name: Version and publish (main) 📦
         if: github.ref == 'refs/heads/main'
         run: |
-          yarn lerna version --conventional-commits --conventional-graduate --yes
+          yarn lerna version --conventional-graduate --force-publish --yes
           yarn lerna publish from-git --yes
 
       - name: Version and publish (beta) 📦
         if: github.ref == 'refs/heads/develop'
         run: |
-          yarn lerna version --conventional-commits --conventional-prerelease --preid beta --yes
+          yarn lerna version --conventional-prerelease --preid beta --yes
           yarn lerna publish from-git --yes --dist-tag next

--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,8 @@
   "version": "0.4.0-beta.1",
   "command": {
     "version": {
-      "message": "chore: publish %s\n\n[skip ci]"
+      "message": "chore: publish %s\n\n[skip ci]",
+      "conventionalCommits": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@blindnet/pc4w-root",
   "description": "Collection of Web Components helping developers to execute privacy-by-design and privacy UX.",
   "license": "MIT",
-  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
- use conventionalCommits by default
- [ignore `lerna changed`](https://github.com/lerna/lerna/tree/main/commands/version#--force-publish) when bumping versions in main (bumping the version of all packages, including the unchanged ones, to enforce version numbers are always in sync)
- remove the version number of the root package (as it [isn't included in lerna version by default](https://github.com/lerna/lerna/issues/2879) and no workaround seems useful)