### PR TITLE
ci: don't commit beta releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,9 @@ jobs:
           yarn lerna version --conventional-graduate --force-publish --yes
           yarn lerna publish from-git --yes
 
-      - name: Version and publish (beta) 📦
+      - name: Publish (beta) 📦
         if: github.ref == 'refs/heads/develop'
         run: |
-          yarn lerna version --conventional-prerelease --preid beta --yes
-          yarn lerna publish from-git --yes --dist-tag next
+          yarn lerna publish --loglevel silly \
+           --yes --no-git-tag-version --no-push \
+           --dist-tag next --preid beta-$(git rev-parse --short HEAD)


### PR DESCRIPTION
Avoid committing releases from the develop branch has it makes the changelog confusing.

Unfortunately, I didn't find any solution to increment the beta version number without commits for now, so I used the last commit hash instead (same as for PRs).