### PR TITLE
ci: beta releases are now canary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,5 +62,5 @@ jobs:
         if: github.ref == 'refs/heads/develop'
         run: |
           yarn lerna publish --loglevel silly \
-           --yes --no-git-tag-version --no-push \
+           --canary --yes --no-git-tag-version --no-push \
            --dist-tag next --preid beta-$(git rev-parse --short HEAD)


### PR DESCRIPTION
use the canary option to make sure lerna doesn't try to release a
conventional version number