### PR TITLE
ci: disablow merge and revert commits on PRs

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -16,5 +16,6 @@ scopes:
   - '@blindnet/core'
   - '@blindnet-demos/devkit-simple-tutorial'
   - '@blindnet-demos/static'
-allowMergeCommits: true
+allowMergeCommits: false
+allowRevertCommits: false
 targetUrl: 'https://github.com/blindnet-io/privacy-components-web/blob/main/CONTRIBUTING.md#-commit-message-guidelines'


### PR DESCRIPTION
Semantic-prs is only required for PRs targetting the develop branch.
It will fail for release PRs (targetting the main branch), but you can just ignore it.