### PR TITLE
ci: set git remote origin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           git config --global user.name "blindnet bot"
           git config --global user.email "dev@blindnet.io"
+          git remote set-url origin https://github.com/${{ github.repository }}
           echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > .npmrc
 
       - name: Version and publish (main) 📦


### PR DESCRIPTION
define a git remote so Lerna can push to the main branch (apparently not correctly handled by actions/checkout)

> **Warning**
>
> The issue could also be linked to Lerna not properly handling push. In that case, we should push manually instead (add the `--no-push` argument to Lerna version and use `git push --follow-tags` instead).

see https://github.com/blindnet-io/privacy-components-web/runs/8202788472?check_suite_focus=true#step:8:13 compared to https://github.com/blindnet-io/privacy-components-web/runs/7797305609 (https://github.com/blindnet-io/privacy-components-web/commit/ee573dfe048c80e04623bc16bf437060eb19494c#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R53)