### PR TITLE
ci: don't use lerna to push branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,8 @@ jobs:
       - name: Version and publish (main) 📦
         if: github.ref == 'refs/heads/main'
         run: |
-          yarn lerna version --conventional-graduate --force-publish --yes
+          yarn lerna version --conventional-graduate --force-publish --yes --no-push
+          git push --follow-tags
           yarn lerna publish from-git --yes
 
       - name: Update develop (from main) 🔀


### PR DESCRIPTION
Lerna seems to have several issues when trying to push a branch after a release so we'll push directly with git instead.

see #101 and https://github.com/blindnet-io/privacy-components-web/runs/8225337458#step:8:14