### PR TITLE
ci: git push upstream

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,15 +57,15 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           yarn lerna version --conventional-graduate --force-publish --yes --no-push
-          git push --follow-tags
+          git push origin main --follow-tags
           yarn lerna publish from-git --yes
 
       - name: Update develop (from main) 🔀
         if: github.ref == 'refs/heads/main'
-        # develop is pulled again in case it has been updated after the initial checkout step
+        # updating the repo in case it has been changed after the initial checkout step
         run: |
+          git fetch origin
           git checkout origin/develop
-          git pull origin develop
           git merge main
           git push origin develop
 


### PR DESCRIPTION
Well, apparently, actions/checkout doesn't properly set the branch upstream either, so let's just directly define that.