### PR TITLE
ci: fix merge of main to develop after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,8 @@ jobs:
           git fetch origin
           git checkout origin/develop
           git merge main
-          git push origin develop
+          git push origin HEAD:develop
+          git checkout main
 
       - name: Publish (beta) 📦
         if: github.ref == 'refs/heads/develop'


### PR DESCRIPTION
After checking out the origin/develop branch, git is in a detached head state and doesn't know what to push, so we need to specify we want to push HEAD to origin/develop.