### PR TITLE
fix(@blindnet-demos/static): wrong script URLs

### DIFF
--- a/demos/static/index.html
+++ b/demos/static/index.html
@@ -23,14 +23,11 @@
     </div>
 
     <script
-      src="../../packages/prci/dist/index.mapped.min.js"
+      src="../../packages/prci/index.mapped.min.js"
       type="module"
     ></script>
     <!-- <script src="https://unpkg.com/@blindnet/prci/dist/index.core.min.js?module" type="module" ></script> -->
-    <script
-      src="../packages/dci/dist/index.mapped.min.js"
-      type="module"
-    ></script>
+    <script src="../../packages/dci/index.mapped.min.js" type="module"></script>
     <!-- <script src="https://unpkg.com/@blindnet/dci/dist/index.core.min.js?module" type="module" ></script> -->
   </body>
 </html>


### PR DESCRIPTION
the bundle script copies the dist/ folder of every package, not the root one, contrarily to npm pack (hence the different paths in unpkg and local URLs)