### PR TITLE
build: only build raw on watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:localize": "lerna run localize",
     "build:rollup": "rollup -c",
     "build": "yarn run build:imports && yarn run build:localize && yarn run build:rollup",
-    "watch": "yarn run build:rollup --configKeep --watch",
+    "watch": "yarn run build:rollup --configKeep --configRaw --watch",
     "analyze": "lerna exec -- \"cem analyze --litelement\"",
     "start": "wds",
     "preinstall": "node -e \"if(process.env.npm_execpath.indexOf('yarn') === -1) throw new Error('Use yarn')\"",


### PR DESCRIPTION
Rollup fails to rewrite raw build files when using watch mode, while bundled files are overwritten correctly. This seems to be linked to Rollup having issues when running watch mode with several build configs. As a workaround, the npm watch script now only runs the first "raw" build in the configuration (the one for npm). This should be enough as demos and storybook only use this build, while the bundles are only used in the static demo (which require rerunning the bundle script anyway) or when loading them from the unpkgr CDN (and well, we can't have a watch on this).