### PR TITLE
chore(@blindnet-demos/devkit-simple-tutorial): update base href

### DIFF
--- a/demos/devkit-simple-tutorial/index.html
+++ b/demos/devkit-simple-tutorial/index.html
@@ -8,7 +8,7 @@
     />
     <meta name="Description" content="Simple tutorial for blindnet devkit" />
     <link rel="icon" href="./assets/favicon.svg" />
-    <base href="/privacy-components-web/demos/devkit-simple-tutorial/" />
+    <base href="/demos/devkit-simple-tutorial/" />
     <link
       rel="stylesheet"
       href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css"

--- a/demos/devkit-simple-tutorial/web-dev-server.config.mjs
+++ b/demos/devkit-simple-tutorial/web-dev-server.config.mjs
@@ -25,5 +25,5 @@ export default /** @type {import('@web/dev-server').DevServerConfig} */ ({
   // See documentation for all available options
   // https://modern-web.dev/docs/dev-server/cli-and-configuration/
 
-  basePath: '/privacy-components-web/demos/devkit-simple-tutorial/',
+  basePath: '/demos/devkit-simple-tutorial/',
 });


### PR DESCRIPTION
removing the repository name from the base href as we are moving from the automatically associated GitHub pages URL to pc4w.blindnet.dev