### PR TITLE
chore(@blindnet/prci): retrieve user from local storage 

### DIFF
--- a/demos/devkit-simple-tutorial/src/views/Form.js
+++ b/demos/devkit-simple-tutorial/src/views/Form.js
@@ -131,7 +131,10 @@ export class AppParticipateForm extends LitElement {
     this._notificationSuccess.open = true;
   }
 
-  async giveConsent() {
+  /**
+   * @param {String} uid
+   */
+  async giveConsent(uid) {
     const headers = {
       'Content-Type': 'application/json',
       'Access-Control-Allow-Origin': '*',
@@ -143,7 +146,8 @@ export class AppParticipateForm extends LitElement {
         headers,
         body: JSON.stringify({
           dataSubject: {
-            id: 'fdfc95a6-8fd8-4581-91f7-b3d236a6a10e',
+            // id: 'fdfc95a6-8fd8-4581-91f7-b3d236a6a10e',
+            id: uid,
             schema: 'dsid',
           },
           consentId: '28b5bee0-9db8-40ec-840e-64eafbfb9ddd',
@@ -204,7 +208,10 @@ export class AppParticipateForm extends LitElement {
       if (this.consentGiven) {
         this.requireConsent = false;
         await this.saveDataToServer(formData);
-        await this.giveConsent();
+        // TODO: remove this when auth is implemented
+        const uid = formData.get('email')?.toString() || 'john.doe@example.com';
+        localStorage.setItem('priv_user_id', uid);
+        await this.giveConsent(uid);
         this.setSubmitting(true);
         this.setValidity();
       } else {

--- a/packages/prci/src/BldnPrivRequest.ts
+++ b/packages/prci/src/BldnPrivRequest.ts
@@ -113,7 +113,9 @@ export class BldnPrivRequest extends LitElement {
     data_subject: [
       {
         // FIXME: For now we hardcode this, but will come from token once auth added
-        id: 'fdfc95a6-8fd8-4581-91f7-b3d236a6a10e',
+        // id: 'fdfc95a6-8fd8-4581-91f7-b3d236a6a10e',
+        // TODO: remove this when auth is implemented
+        id: localStorage.getItem('priv_user_id') || 'john.doe@example.com',
         schema: 'dsid',
       },
     ],
@@ -219,7 +221,9 @@ export class BldnPrivRequest extends LitElement {
       data_subject: [
         {
           // FIXME: For now we hardcode this, but will come from token once auth added
-          id: 'fdfc95a6-8fd8-4581-91f7-b3d236a6a10e',
+          // id: 'fdfc95a6-8fd8-4581-91f7-b3d236a6a10e',
+          // TODO: remove this when auth is implemented
+          id: localStorage.getItem('priv_user_id') || 'john.doe@example.com',
           schema: 'dsid',
         },
       ],

--- a/packages/prci/src/utils/privacy-request-api.ts
+++ b/packages/prci/src/utils/privacy-request-api.ts
@@ -64,6 +64,9 @@ export async function sendPrivacyRequest(
     : {
         'Content-Type': 'application/json',
         'Access-Control-Allow-Origin': '*',
+        // TODO: remove this when auth is implemented
+        Authorization:
+          localStorage.getItem('priv_user_id') || 'john.doe@example.com',
       };
   return fetch(url, {
     method: 'POST',
@@ -82,7 +85,12 @@ export async function getRequestHistory() {
     'https://devkit-pce-staging.azurewebsites.net/v0/privacy-request/history',
     {
       method: 'GET',
-      headers: { accept: 'application/json' },
+      headers: {
+        accept: 'application/json',
+        // TODO: remove this when auth is implemented
+        Authorization:
+          localStorage.getItem('priv_user_id') || 'john.doe@example.com',
+      },
     }
   ).then(response => {
     if (!response.ok) {
@@ -97,7 +105,12 @@ export async function getRequest(requestId: string) {
     `https://devkit-pce-staging.azurewebsites.net/v0/privacy-request/${requestId}`,
     {
       method: 'GET',
-      headers: { accept: 'application/json' },
+      headers: {
+        accept: 'application/json',
+        // TODO: remove this when auth is implemented
+        Authorization:
+          localStorage.getItem('priv_user_id') || 'john.doe@example.com',
+      },
     }
   ).then(response => {
     if (!response.ok) {


### PR DESCRIPTION
This is a change for the demo. ACCESS request should return data about a user who submitted the prizes form.
The user id (email) is stored and retrieved from the local storage.