### PR TITLE
build: fix typeschecking

### DIFF
--- a/demos/devkit-simple-tutorial/package.json
+++ b/demos/devkit-simple-tutorial/package.json
@@ -4,6 +4,7 @@
   "version": "0.8.1",
   "license": "MIT",
   "private": true,
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/blindnet-io/privacy-components-web.git",

--- a/demos/devkit-simple-tutorial/rollup.config.js
+++ b/demos/devkit-simple-tutorial/rollup.config.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import nodeResolve from '@rollup/plugin-node-resolve';
 import babel from '@rollup/plugin-babel';
 import html from '@web/rollup-plugin-html';

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import * as path from 'path';
 import { glob } from 'glob';
 

--- a/tasks/rollup-base-config.js
+++ b/tasks/rollup-base-config.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /* eslint-disable import/no-extraneous-dependencies */
 import path from 'path';
 import * as fs from 'fs';


### PR DESCRIPTION
fix `yarn typecheck` by disabling type-checking on rollup config files,
as they depend on way too many packages with buggy type definition and
configuration, and set the devkit-simple-tutorial as an ESM project to
avoid errors when using packages with ESM only (like @open-wc/testing)
and browser / ESM specific things like `import.meta`