### PR TITLE
fix(@blindnet-demos/devkit-simple-tutorial): fix gh pages routing

### DIFF
--- a/demos/devkit-simple-tutorial/src/DevkitSimpleTutorial.js
+++ b/demos/devkit-simple-tutorial/src/DevkitSimpleTutorial.js
@@ -96,6 +96,23 @@ export class DevkitSimpleTutorial extends LitElement {
   }
 
   render() {
+    // Hack to get around the lack of support for routes in github pages
+    const params = new URLSearchParams(window.location.search);
+    const path = params.get('path');
+    if (path) {
+      // Go only works with a (very small) timeout
+      setTimeout(() => {
+        Router.go(
+          `${window.location.origin}/demos/devkit-simple-tutorial/${path}`
+        );
+        // Would do below here to keep params but vaadin doesn't like the path when passed that way
+        // Router.go({
+        //   pathname: `${window.location.origin}/demos/devkit-simple-tutorial/${path}`,
+        //   search: params.toString()
+        // })
+      }, 1);
+    }
+
     return html`
       <bx-header aria-label="blindnet devkit simple tutorial">
         <bx-header-menu-button

--- a/demos/devkit-simple-tutorial/src/views/Privacy.js
+++ b/demos/devkit-simple-tutorial/src/views/Privacy.js
@@ -7,15 +7,13 @@ import jwt_decode from 'jwt-decode';
 
 import '@blindnet/prci';
 
-// window.Buffer = Buffer
-
 // Get an auth0 instance
 const auth0 = new Auth0Client({
   domain: 'blindnet.eu.auth0.com',
   client_id: '1C0uhFCpzvJAkFi4uqoq2oAWSgQicqHc',
-  redirect_uri: `${window.location.origin}/demos/devkit-simple-tutorial/privacy`,
+  redirect_uri: `${window.location.origin}/demos/devkit-simple-tutorial/?path=privacy`,
   authorizationParams: {
-    redirect_uri: `${window.location.origin}/demos/devkit-simple-tutorial/privacy`,
+    redirect_uri: `${window.location.origin}/demos/devkit-simple-tutorial/?path=privacy`,
   },
 });
 
@@ -54,7 +52,7 @@ export class AppPrivacy extends LitElement {
   }
 
   handleLoginClick() {
-    window.location.href = `${window.location.origin}/demos/devkit-simple-tutorial/login`;
+    auth0.loginWithRedirect();
   }
 
   handleLogoutClick() {


### PR DESCRIPTION
Github pages doesn't natively support react frontend routing like we do in the demo. This means that the redirects from our login page in the demo will go to a 404 page. To get around this we can set a query parameter with the path we want to route to, and parse it on the frontend side.