### PR TITLE
feat(@blindnet-demos/devkit-simple-tutorial) add audience option to auth0 client

### DIFF
--- a/demos/devkit-simple-tutorial/src/views/Login.js
+++ b/demos/devkit-simple-tutorial/src/views/Login.js
@@ -7,6 +7,7 @@ import { Auth0Client } from '@auth0/auth0-spa-js';
 const auth0 = new Auth0Client({
   domain: 'blindnet.eu.auth0.com',
   client_id: '1C0uhFCpzvJAkFi4uqoq2oAWSgQicqHc',
+  audience: 'https://blindnet-connector-demo-staging.azurewebsites.net',
   redirect_uri: `${window.location.origin}/demos/devkit-simple-tutorial/privacy`,
   authorizationParams: {
     redirect_uri: `${window.location.origin}/demos/devkit-simple-tutorial/privacy`,

--- a/demos/devkit-simple-tutorial/src/views/Privacy.js
+++ b/demos/devkit-simple-tutorial/src/views/Privacy.js
@@ -11,6 +11,7 @@ import '@blindnet/prci';
 const auth0 = new Auth0Client({
   domain: 'blindnet.eu.auth0.com',
   client_id: '1C0uhFCpzvJAkFi4uqoq2oAWSgQicqHc',
+  audience: 'https://blindnet-connector-demo-staging.azurewebsites.net',
   redirect_uri: `${window.location.origin}/demos/devkit-simple-tutorial/privacy`,
   authorizationParams: {
     redirect_uri: `${window.location.origin}/demos/devkit-simple-tutorial/privacy`,


### PR DESCRIPTION
This way we can add claims to the access token which can be verified on the server.