### PR TITLE
ditch the login/logout wordings

### DIFF
--- a/demos/devkit-simple-tutorial/src/views/Privacy.js
+++ b/demos/devkit-simple-tutorial/src/views/Privacy.js
@@ -16,6 +16,19 @@ const auth0 = new Auth0Client({
   authorizationParams: {
     redirect_uri: `${window.location.origin}/demos/devkit-simple-tutorial/privacy`,
   },
+  languageDictionary: {
+    title: 'Let us verify your e-mail',
+    passwordlessEmailInstructions:
+      'Enter the email associated<br/>with your data',
+    signUpTerms:
+      'By clicking SUMBIT, you give consent for processing your data (email) for the purposes of identifying you and processing your privacy request.',
+    success: {
+      logIn: 'Email verified.',
+      magicLink: 'We sent you a link to verify<br />your e-mail at %s.',
+    },
+  },
+  allowSignUp: false,
+  passwordlessMethod: `link`,
 });
 
 export class AppPrivacy extends LitElement {
@@ -93,19 +106,19 @@ export class AppPrivacy extends LitElement {
         this._apiToken,
         () => html`
           <span
-            >Logged in as
+            >Making a Privacy Request as
             ${
               // @ts-ignore
               jwt_decode(this._apiToken).uid
             }.</span
           >
           <bldn-button @click=${this.handleLogoutClick} mode="link">
-            Logout
+            Change
           </bldn-button>
         `,
         () => html`
           <bldn-button @click=${this.handleLoginClick} mode="link">
-            Login
+            Verify your e-mail
           </bldn-button>
         `
       )}


### PR DESCRIPTION
Proposing alternative wordings to make it clear that users don't have an account here, they only verify their e-mail to be able to make a personalized reuqest.

@jboileau99 pleaste test if it works and merge if you accept the change