### PR TITLE
fix: map imports for runtime localization

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "fix-locales": "node ./tasks/fix-locale-imports.js",
     "build:imports": "lerna exec --scope \"@blindnet/*\" -- \"importly --host=unpkg --lookup=unpkg --semver=minor < package.json > import-map.json\"",
     "build:localize": "node ./tasks/copy-localization-config.js && lerna run localize",
+    "build:fix-locales": "node ./tasks/build-fix-locales.js",
     "build:rollup": "rollup -c",
-    "build": "yarn run build:imports && yarn run build:localize && yarn run build:rollup",
+    "build": "yarn run build:imports && yarn run build:localize && yarn run build:rollup && yarn run build:fix-locales",
     "watch": "yarn run build:rollup --configKeep --configRaw --watch",
     "analyze": "lerna exec -- \"cem analyze --litelement\"",
     "start": "wds",
@@ -40,7 +41,6 @@
     "ignore-sync": "ignore-sync .",
     "bundle:build-demos": "lerna run build --scope \"@blindnet-demos/*\"",
     "bundle:copy": "node ./tasks/bundle-copy.js",
-    "bundle:fix-locales": "node ./tasks/bundle-fix-locales.js",
     "bundle": "yarn bundle:build-demos && yarn storybook:build && yarn bundle:copy && yarn bundle:fix-locales"
   },
   "dependencies": {

--- a/packages/prci/src/bldn-priv-request.ts
+++ b/packages/prci/src/bldn-priv-request.ts
@@ -11,7 +11,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 
 import './bldn-request-builder.js';
 import './bldn-submitted-requests.js';
-import { setLocale, getLocale } from './utils/localization.js';
+import { setLocale } from './utils/localization.js';
 
 enum PRCIUIState {
   createRequest,
@@ -38,9 +38,7 @@ export class BldnPrivRequest extends CoreConfigurationMixin(LitElement) {
 
     // Set locale if current one is supported
     try {
-      setLocale(navigator.language).then(() => {
-        console.log(`Set locale to ${getLocale()}`);
-      });
+      setLocale(navigator.language);
     } catch (e) {
       // eslint-disable-next-line no-console
       console.log(`Could not set locale to ${navigator.language}.`);

--- a/packages/prci/src/bldn-request-builder.ts
+++ b/packages/prci/src/bldn-request-builder.ts
@@ -19,6 +19,7 @@ import './action-forms/bldn-restrict-form.js';
 import './action-forms/bldn-revoke-consent-form.js';
 import './action-forms/bldn-transparency-form.js';
 import './action-forms/bldn-other-form.js';
+import { localized } from '@lit/localize';
 import { ACTION_DESCRIPTIONS, ACTION_TITLES } from './utils/dictionary.js';
 
 /**
@@ -70,6 +71,7 @@ enum RequestBuilderUIState {
   review,
 }
 
+@localized()
 @customElement('bldn-request-builder')
 export class BldnRequestBuilder extends CoreConfigurationMixin(LitElement) {
   /** @prop */

--- a/packages/prci/src/bldn-submitted-requests.ts
+++ b/packages/prci/src/bldn-submitted-requests.ts
@@ -1,5 +1,5 @@
 import { ComputationAPI, CoreConfigurationMixin, PrItem } from '@blindnet/core';
-import { msg } from '@lit/localize';
+import { localized, msg } from '@lit/localize';
 import { css, html, LitElement, PropertyValueMap } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { when } from 'lit/directives/when.js';
@@ -36,6 +36,7 @@ const filterOptions = [
   },
 ];
 
+@localized()
 @customElement('bldn-submitted-requests')
 export class BldnSubmittedRequests extends CoreConfigurationMixin(LitElement) {
   @property({ type: String, attribute: 'request-id' }) requestId:

--- a/tasks/build-fix-locales.js
+++ b/tasks/build-fix-locales.js
@@ -2,18 +2,19 @@
 /* eslint-disable no-console */
 import fs from 'fs-extra';
 
-const packages = fs.readdirSync('./build/packages');
+const packages = fs.readdirSync('./packages');
 
 packages.forEach(pack => {
   const localeFiles = fs.readdirSync(
-    `./build/packages/${pack}/generated/locales`
+    `./packages/${pack}/dist/generated/locales`
   );
   localeFiles
     .filter(f => f.endsWith('.js'))
     .forEach(localeFile => {
+      console.log(`./packages/${pack}/dist/generated/locales/${localeFile}`);
       const result = fs
         .readFileSync(
-          `./build/packages/${pack}/generated/locales/${localeFile}`,
+          `./packages/${pack}/dist/generated/locales/${localeFile}`,
           'utf-8'
         )
         .replace(
@@ -24,8 +25,9 @@ packages.forEach(pack => {
           "'@lit/localize'",
           "'https://unpkg.com/@lit/localize@latest/lit-localize.js?module'"
         );
+      console.log(result);
       fs.writeFile(
-        `./build/packages/${pack}/generated/locales/${localeFile}`,
+        `./packages/${pack}/dist/generated/locales/${localeFile}`,
         result,
         'utf8',
         err => {


### PR DESCRIPTION
replaces `lit` and `lit-localize` imports in generated translation files with their CDN urls, mimicking the functionality of [import maps](https://www.digitalocean.com/community/tutorials/how-to-dynamically-import-javascript-with-import-maps).